### PR TITLE
Self-karma positive or negative messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ API
 * `thing--` - remove a point from `thing`
 * `--` - remove a point from the most previously voted-on thing
 * `thing-- for stuff` - keep track of why you removed thing points
+* `@me++` - get scolded (via configurable `SELF_KARMA_SCOLDING` message) for attempting to add a point to oneself
 * `hubot erase thing` - erase thing from scoreboard (permanently deletes thing from memory)
 * `hubot erase thing for reason` erase given reason from thing's score board (does not deduct from total score)
 * `hubot top 10` - show the top 10, with a graph of points

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ API
 * `--` - remove a point from the most previously voted-on thing
 * `thing-- for stuff` - keep track of why you removed thing points
 * `@me++` - get scolded (via configurable `SELF_KARMA_SCOLDING` message) for attempting to add a point to oneself
+* `@me--` - get reassured (via configurable `HUMILITY_SCOLDING` message) for attempting to remove a point from oneself
 * `hubot erase thing` - erase thing from scoreboard (permanently deletes thing from memory)
 * `hubot erase thing for reason` erase given reason from thing's score board (does not deduct from total score)
 * `hubot top 10` - show the top 10, with a graph of points

--- a/src/mega-plusplus.coffee
+++ b/src/mega-plusplus.coffee
@@ -44,6 +44,7 @@ module.exports = (robot) ->
   maxPoints = process.env.HUBOT_PLUSPLUS_MAX_POINTS or 5
   reasonConjunctions = process.env.HUBOT_PLUSPLUS_CONJUNCTIONS or 'for|because|cause|cuz|as'
   selfKarmaScolding = process.env.SELF_KARMA_SCOLDING or 'Did you really just try to give yourself karma?  REALLY?!'
+  humilityScolding = process.env.HUMILITY_SCOLDING or 'There there, buddy... it\'s gonna be all right.'
 
   # sweet regex bro
   robot.hear ///
@@ -80,7 +81,8 @@ module.exports = (robot) ->
     # do the {up, down}vote, and figure out what the new score is
     requestedMagnitude = (operator.length - 1)
     magnitude = Math.min(requestedMagnitude, maxPoints)
-    [score, reasonScore] = if operator.charAt(0) == "+"
+    wasAPositiveChange = operator.charAt(0) == "+"
+    [score, reasonScore] = if wasAPositiveChange
               scoreKeeper.addX(name, from, magnitude, room, reason)
             else
               scoreKeeper.subtractX(name, from, magnitude, room, reason)
@@ -112,7 +114,11 @@ module.exports = (robot) ->
         from:      from
       }
     else if name == from
-      msg.send selfKarmaScolding
+      if wasAPositiveChange
+        msg.send selfKarmaScolding
+      else
+        msg.send humilityScolding
+
 
   robot.respond ///
     (?:erase\s+)

--- a/src/mega-plusplus.coffee
+++ b/src/mega-plusplus.coffee
@@ -43,6 +43,7 @@ module.exports = (robot) ->
   reasonsKeyword = process.env.HUBOT_PLUSPLUS_REASONS or 'raisins'
   maxPoints = process.env.HUBOT_PLUSPLUS_MAX_POINTS or 5
   reasonConjunctions = process.env.HUBOT_PLUSPLUS_CONJUNCTIONS or 'for|because|cause|cuz|as'
+  selfKarmaScolding = process.env.SELF_KARMA_SCOLDING or 'Did you really just try to give yourself karma?  REALLY?!'
 
   # sweet regex bro
   robot.hear ///
@@ -110,6 +111,8 @@ module.exports = (robot) ->
         reason:    reason
         from:      from
       }
+    else if name == from
+      msg.send selfKarmaScolding
 
   robot.respond ///
     (?:erase\s+)


### PR DESCRIPTION
## Description
- Scold a user for attempting to give themself karma
- Encourage a user who attempted to remove karma from themself

## QA
- [x] Confirm default self-plus works:
```
jetbot> shell++
jetbot> Did you really just try to give yourself karma?  REALLY?!
```
- [x] Confirm default self-minus works:
```
jetbot> shell--
jetbot> There there, buddy... it's gonna be all right.
```

- [x] `SELF_KARMA_SCOLDING='For shame.' HUMILITY_SCOLDING="You're FINE" bin/hubot`
- [x] Confirm custom messaging works:
```
jetbot> shell++
jetbot> For shame.
jetbot> shell--
jetbot> You're FINE
```

## Related Issue
closes #5