### PR TITLE
Update coffeescript package to latest and fix test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A hubot script for adding or removing points, in a more Hipchat Karma bot way",
   "main": "index.coffee",
   "scripts": {
-    "test": "mocha --compilers coffee:coffee-script --recursive ./test"
+    "test": "mocha --require coffeescript/register --recursive ./test/**/*.coffee"
   },
   "repository": {
     "type": "git",
@@ -23,14 +23,14 @@
     "url": "https://github.com/jetpackworkflow/hubot-mega-plusplus/issues"
   },
   "dependencies": {
-    "coffee-script": "~1.6",
+    "coffeescript": "~2.5.1",
     "underscore": ">= 1.0",
     "clark": "0.0.6"
   },
   "devDependencies": {
-    "mocha": "*",
     "chai": "*",
-    "sinon-chai": "*",
-    "sinon": "*"
+    "mocha": "*",
+    "sinon": "*",
+    "sinon-chai": "*"
   }
 }


### PR DESCRIPTION
The `coffee-script` package has been deprecated for a while and moved to `coffeescript`. This updates to the latest version of coffeescript. 

The `test` script was also broken, but should work now.

### QA
- [ ] Checkout master and try to run the tests with `npm test`
- [ ] Verify it fails with a message about the `--compilers` flag being deprecated for `mocha`
- [ ] Checkout this branch
- [ ] Run tests and verify they pass